### PR TITLE
Dotted circle, fix anchor names

### DIFF
--- a/sources/AguDisplay.glyphs
+++ b/sources/AguDisplay.glyphs
@@ -136,7 +136,11 @@ IV
 a,
 ",
 "◌̨",
-"+−×÷=≠><%"
+"+−×÷=≠><%",
+"̵",
+"◌",
+"˛",
+"᷅"
 );
 axes = (
 {
@@ -248566,7 +248570,7 @@ unicode = 9633;
 category = Symbol;
 color = 5;
 glyphname = DottedCircle;
-lastChange = "2024-11-11 11:24:38 +0000";
+lastChange = "2024-11-12 14:08:46 +0000";
 layers = (
 {
 anchors = (
@@ -249095,15 +249099,15 @@ width = 1000;
 {
 anchors = (
 {
-name = _center;
+name = bottom;
+},
+{
+name = center;
 pos = (141,324);
 },
 {
-name = _ogonek;
+name = ogonek;
 pos = (239,-14);
-},
-{
-name = bottom;
 },
 {
 name = top;

--- a/sources/AguDisplay.glyphs
+++ b/sources/AguDisplay.glyphs
@@ -248570,20 +248570,20 @@ unicode = 9633;
 category = Symbol;
 color = 5;
 glyphname = DottedCircle;
-lastChange = "2024-11-12 14:08:46 +0000";
+lastChange = "2024-11-12 14:15:26 +0000";
 layers = (
 {
 anchors = (
 {
-name = _center;
+name = bottom;
+},
+{
+name = center;
 pos = (141,324);
 },
 {
-name = _ogonek;
+name = ogonek;
 pos = (239,-14);
-},
-{
-name = bottom;
 },
 {
 name = top;
@@ -249623,15 +249623,15 @@ width = 1000;
 {
 anchors = (
 {
-name = _center;
+name = bottom;
+},
+{
+name = center;
 pos = (141,324);
 },
 {
-name = _ogonek;
+name = ogonek;
 pos = (239,-14);
-},
-{
-name = bottom;
 },
 {
 name = top;


### PR DESCRIPTION
This renames a couple of anchor points on the Dotted Circle glyph, to fix Fontbakery fails.