### PR TITLE
Update build.yaml to restore actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Install sys tools/deps
       run: |
         sudo apt-get update
-        sudo apt-get install ttfautohint
+        sudo apt-get install ttfautohint libcairo2-dev python3-cairo-dev pkg-config python3-dev
         sudo snap install yq
     - uses: actions/cache@v4
       with:


### PR DESCRIPTION
This incorporates an upstream fix from the template repo that gets the Github Actions working again.